### PR TITLE
Add options for url, singlePage and title for PDF generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Single-page document, default settings (format: `A4`, orientation: `portrait`):
 Both methods handle the following query parameters:
 
 - `filename`: the name of the resulting PDF file (will automatically append the `.pdf` extension if absent)
+- `title`: the title of the resulting PDF if the provided html does not contain a <title> tag, falls back to filename without extension if provided
+- `singlePage`: create PDF with a single page containing all the content (not supported with `/multiple`)
 - all the options supported by [Puppeteer's page#pdf(\[options\])](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagepdfoptions), except:
   - `path`
   - `headerTemplate`
@@ -136,5 +138,6 @@ Includes a comprehensive script that lets you build and publish new versions of 
 
 ## License
 
-MIT. Do as you please.  
+MIT. Do as you please.
+
 Refer to the [LICENSE](./LICENSE) file for more details.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,8 +13,12 @@ export default antfu({
     'style/no-floating-decimal': 'off',
     'no-sequences':              'off',
     'prefer-arrow-callback':     'off',
+    'prefer-template':           'off',
     'style/key-spacing':         ['warn', { align: 'value' }],
     'style/no-multi-spaces':     'off',
     'style/quotes':              ['warn', 'single', { avoidEscape: true }],
   },
+}, {
+  files: ['*.md'],
+  rules: { 'style/no-trailing-spaces': 'off' },
 })

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "body-parser": "^2.2.1",
     "cors": "^2.8.5",
     "express": "^5.2.1",
-    "pdfjs": "^2.5.4",
+    "pdf-lib": "^1.17.1",
     "puppeteer-core": "^24.34.0",
     "rxjs": "^7.8.2",
     "tsx": "^4.21.0",

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1,0 +1,62 @@
+import type { PDFOptions } from 'puppeteer-core'
+import { Buffer } from 'node:buffer'
+import { PDFDocument } from 'pdf-lib'
+import { Page } from 'puppeteer-core'
+import { withBrowser } from './shared-browser'
+
+export interface PDFInfo { title?: string, author?: string, subject?: string, keywords?: string, creator?: string, producer?: string, creationDate?: Date, modificationDate?: Date }
+export interface ExtraOpts { onepage?: boolean  }
+export interface PrinterConfig {
+  data: string[]
+  cfg:  PDFOptions & PDFInfo & ExtraOpts
+}
+
+export function printHTML(cfg: PrinterConfig) {
+  return print(cfg, Page.prototype.setContent)
+}
+
+export function printURLs(cfg: PrinterConfig) {
+  return print(cfg, Page.prototype.goto)
+}
+
+function print({ data, cfg }: PrinterConfig, load: typeof Page.prototype.setContent | typeof Page.prototype.goto) {
+  return withBrowser(async browser => await combine(await Promise.all(data.map(async function (datum) {
+    const page = await browser.newPage()
+    await load.call(page, datum, { waitUntil: 'networkidle0' })
+    const content = await page.pdf({
+      format:          'a4',
+      landscape:       false,
+      printBackground: true,
+      ...cfg,
+      ...cfg.onepage ? { format: undefined, landscape: undefined, ...(await page.evaluate(docDimensions)) } : {},
+      margin:          { top: 0, right: 0, bottom: 0, left: 0 },
+      path:            undefined,
+    })
+    await page.close()
+    return content
+  })), cfg))
+}
+
+async function combine(pdfs: Uint8Array[], info: PDFInfo): Promise<Buffer> {
+  if (!pdfs.length) return Buffer.from(await (await PDFDocument.create()).save())
+  const [out, ...docs] = await Promise.all(pdfs.map(buf => PDFDocument.load(buf)))
+  await allSequential(docs, async doc => (await out.copyPages(doc, doc.getPageIndices())).forEach(p => out.addPage(p)))
+  Object.entries(info).forEach(([k, v]) => out['set' + k[0].toUpperCase() + k.slice(1)]?.(v))
+  return Buffer.from(await out.save())
+}
+
+function docDimensions() {
+  const body = document.body
+  const html = document.documentElement
+  return {
+    height: Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight) + 'px',
+    width:  Math.max(body.scrollWidth,  body.offsetWidth,  html.clientWidth,  html.scrollWidth,  html.offsetWidth)  + 'px',
+  }
+}
+
+function allSequential<I, R>(input: I[], fn: (i: I) => Promise<R>): Promise<R[]> {
+  return input.reduce(
+    (prev, next) => prev.then(res => fn(next).then(r => [...res, r])),
+    Promise.resolve([] as R[]),
+  )
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,10 @@
 import type { Request, Response } from 'express'
-import type { PDFOptions } from 'puppeteer-core/lib/types'
+import type { PrinterConfig } from './printer'
 import process from 'node:process'
 import bodyParser from 'body-parser'
 import cors from 'cors'
 import express from 'express'
-import { Document, ExternalDocument } from 'pdfjs'
-import { print } from './shared-browser'
+import { printHTML, printURLs } from './printer'
 
 const port = 3000
 const limit = process.env.BODY_LIMIT || '1mb'
@@ -13,19 +12,24 @@ const limit = process.env.BODY_LIMIT || '1mb'
 express()
   .use(express.json({ limit }))
   .use(bodyParser.text({ type: 'text/html', limit }))
+  .use(bodyParser.text({ type: 'text/plain', limit }))
 
   // Accepts a single HTML document in the body
   .post('/', cors(), async (req: Request, res: Response) => {
-    const { filename, opts } = parseRequest(req.query as Record<string, string>)
-    res.attachment(filename.replace(/(?:\.pdf)?$/, '.pdf')).send((await print(req.body, opts)))
+    const { filename, cfg } = parseRequest(req.query as Record<string, string>)
+    res.attachment(filename).send(await printHTML({ cfg, data: [req.body as string] }))
   })
 
-  // Accepts multiple HTML documents in the body as a Json array of strings
+  // Accepts a list of URLs in the body
+  .post('/url', cors(), async (req: Request, res: Response) => {
+    const { filename, cfg } = parseRequest(req.query as Record<string, string>)
+    res.attachment(filename).send(await printURLs({ cfg, data: (req.body as string).split(/\n/).filter(({ length }) => length) }))
+  })
+
+  // Accepts multiple HTML documents in the body as a JSON array of strings
   .post('/multiple', cors(), async (req: Request, res: Response) => {
-    const { filename, opts } = parseRequest(req.query as Record<string, string>)
-    const pages = await Promise.all((req.body as string[]).map(html => print(html, { ...opts })))
-    const doc = pages.reduce((merged, content) => (merged.addPagesOf(new ExternalDocument(content)), merged), new Document())
-    res.attachment(filename.replace(/(?:\.pdf)?$/, '.pdf')).send(await doc.asBuffer())
+    const { filename, cfg } = parseRequest(req.query as Record<string, string>)
+    res.attachment(filename).send(await printHTML({ cfg, data: req.body as string[] }))
   })
 
   .options('/{*anything}', cors())
@@ -34,16 +38,19 @@ express()
     console.log(`HTML-to-PDF converter listening on port: ${port}`)
   })
 
-// Parse all the parameters to Page#pdf that cannot accept strings
-// See https://pptr.dev/api/puppeteer.pdfoptions
-function parseRequest(query: Record<string, string>): { filename: string, opts: PDFOptions } {
-  const sanitised = Object.fromEntries(Object.entries(query).map(([k, v]) => {
-    if (['displayHeaderFooter', 'landscape', 'omitBackground', 'outline', 'preferCSSPageSize', 'printBackground', 'tagged', 'waitForFonts'].includes(k)) return [k, v === 'true']
-    if (['scale', 'timeout'].includes(k)) return [k, +v]
-    return [k, v]
-  }))
+// Parse:
+// - the parameters to Page#pdf that cannot accept strings        (see https://pptr.dev/api/puppeteer.pdfoptions)
+// - the non-string fields of standard PDF Information Dictionary (creationDate and modDate)
+// - this service's own properties                                (filename and onepage)
+function parseRequest(query: Record<string, string>): { filename: `${string}.pdf`, cfg: PrinterConfig['cfg'] } {
   return {
-    filename: (sanitised.filename || 'document').replace(/(\.pdf)?$/, '.pdf'),
-    opts:     { format: 'a4', landscape: false, printBackground: true, ...sanitised, path: null },
+    filename: (query.filename || 'document').replace(/(\.pdf)?$/, '.pdf') as `${string}.pdf`,
+    cfg:      Object.fromEntries(Object.entries(query).map(([k, v]) => {
+      if (/* pptr#pdf: */ ['displayHeaderFooter', 'landscape', 'omitBackground', 'outline', 'preferCSSPageSize', 'printBackground', 'tagged', 'waitForFonts'].includes(k)) return [k, v === 'true']
+      if (/* pptr#pdf: */ ['scale', 'timeout'].includes(k)) return [k, +v]
+      if (/* infodict: */ ['creationDate', 'modDate'].includes(k)) return [k, new Date(v)]
+      if (/* html2pdf: */ ['onepage'].includes(k)) return [k, v === 'true']
+      return [k, v]
+    })),
   }
 }

--- a/src/shared-browser.ts
+++ b/src/shared-browser.ts
@@ -1,4 +1,4 @@
-import type { Browser, PDFOptions } from 'puppeteer-core'
+import type { Browser } from 'puppeteer-core'
 import process from 'node:process'
 import puppeteer from 'puppeteer-core'
 import { BehaviorSubject, firstValueFrom, from, Observable, of, Subject } from 'rxjs'
@@ -42,14 +42,4 @@ const browser$ = (function sharedBrowser(): Observable<Browser> {
 
 export function withBrowser<T>(fn: (browser: Browser) => Promise<T>): Promise<T> {
   return firstValueFrom(browser$.pipe(switchMap(fn)))
-}
-
-export async function print(html: string, opts: PDFOptions): Promise<Uint8Array<ArrayBufferLike>> {
-  return withBrowser(async (browser) => {
-    const page = await browser.newPage()
-    await page.setContent(html, { waitUntil: 'networkidle0' })
-    const pdf = await page.pdf(opts)
-    await page.close()
-    return pdf
-  })
 }


### PR DESCRIPTION
Adds some small options for the PDF generation process

- accepts a URL instead of HTML content 
- add a `singlePage` parameter which renders the whole content in one single page of the PDF (not supported for the `/multiple` endpoint)
- add a `title` parameter which sets the title of the pdf document if the content does not provide a `<title>` tag (with fallback to `filename` if given)